### PR TITLE
Update Env Table

### DIFF
--- a/core/kps.lua
+++ b/core/kps.lua
@@ -70,7 +70,7 @@ kps.combatStep = function ()
                 LOG.warn("Priority Spell %s was casted.", prioritySpell)
                 prioritySpell = nil
             else
-                if kps.spells.cooldown(prioritySpell) > 3 then prioritySpell = nil end
+                if prioritySpell.cooldown > 3 then prioritySpell = nil end
                 spell.cast(target)
             end
         else

--- a/modules/spell/spell_state.lua
+++ b/modules/spell/spell_state.lua
@@ -55,7 +55,7 @@ end
 
 
 function Spell.isPrioritySpell(self)
-    if rawget(spell,"_isPrioritySpell") == nil then
+    if rawget(self,"_isPrioritySpell") == nil then
         self._isPrioritySpell = not self.isOneOf(kps.spells.ignore)
     end
     return self._isPrioritySpell

--- a/rotations/druid.lua
+++ b/rotations/druid.lua
@@ -188,3 +188,4 @@ kps.spells.druid.incarnation = kps.Spell.fromId(117679)
 kps.spells.druid.shadowmeld = kps.Spell.fromId(135201)
 
 
+kps.env.druid = {}

--- a/rotations/hunter.lua
+++ b/rotations/hunter.lua
@@ -140,3 +140,4 @@ kps.spells.hunter.steadyFocus = kps.Spell.fromId(177667)
 kps.spells.hunter.lockAndLoad = kps.Spell.fromId(168980)
 
 
+kps.env.hunter = {}

--- a/rotations/monk.lua
+++ b/rotations/monk.lua
@@ -159,3 +159,4 @@ kps.spells.monk.comboBreakerEnergize = kps.Spell.fromId(145008)
 kps.spells.monk.tigerPower = kps.Spell.fromId(125359)
 
 
+kps.env.monk = {}

--- a/rotations/paladin.lua
+++ b/rotations/paladin.lua
@@ -170,3 +170,4 @@ kps.spells.paladin.maraadsTruth = kps.Spell.fromId(156990)
 kps.spells.paladin.blazingContempt = kps.Spell.fromId(166831)
 
 
+kps.env.paladin = {}

--- a/rotations/priest.lua
+++ b/rotations/priest.lua
@@ -159,3 +159,4 @@ kps.spells.priest.searingInsanity = kps.Spell.fromId(179337)
 kps.spells.priest.mentalInstinct = kps.Spell.fromId(167254)
 
 
+kps.env.priest = {}

--- a/rotations/rogue.lua
+++ b/rotations/rogue.lua
@@ -133,3 +133,4 @@ kps.spells.rogue.masterPoisoner = kps.Spell.fromId(165390)
 kps.spells.rogue.deepInsight = kps.Spell.fromId(84747)
 
 
+kps.env.rogue = {}

--- a/rotations/shaman.lua
+++ b/rotations/shaman.lua
@@ -168,3 +168,4 @@ kps.spells.shaman.lavaBeam = kps.Spell.fromId(114074)
 kps.spells.shaman.windstrike = kps.Spell.fromId(115356)
 
 
+kps.env.shaman = {}

--- a/rotations/warrior.lua
+++ b/rotations/warrior.lua
@@ -149,4 +149,6 @@ kps.spells.warrior.unyieldingStrikes = kps.Spell.fromId(169685)
 kps.spells.warrior.shieldBarrier = kps.Spell.fromId(174926)
 kps.spells.warrior.siegebreaker = kps.Spell.fromId(176289)
 
+kps.env.warrior = {}
+
 

--- a/rotations/warrior_protection.lua
+++ b/rotations/warrior_protection.lua
@@ -9,7 +9,7 @@ local env = kps.env.warrior
 kps.rotations.register("WARRIOR","PROTECTION",
 {
     {spells.charge}, -- charge
-    {spells.berserkerRage, 'target.hasMyDebuff(spells.enrage)'}, -- berserker_rage,if=buff.enrage.down
+    {spells.berserkerRage, 'not player.hasBuff(spells.enrage)'}, -- berserker_rage,if=buff.enrage.down
     {{"nested"}, 'True', { -- call_action_list,name=prot
         {spells.shieldBlock, 'not ( player.hasBuff(spells.demoralizingShout) or player.hasBuff(spells.ravager) or player.hasBuff(spells.shieldWall) or player.hasBuff(spells.lastStand) or player.hasBuff(spells.enragedRegeneration) or player.hasBuff(spells.shieldBlock) )'}, -- shield_block,if=!(debuff.demoralizing_shout.up|buff.ravager_protection.up|buff.shield_wall.up|buff.last_stand.up|buff.enraged_regeneration.up|buff.shield_block.up)
         {spells.shieldBarrier, 'target.hasMyDebuff(spells.shieldBarrier) and ( ( target.hasMyDebuff(spells.shieldBlock) and spells.shieldBlock.charges < 0.75 ) or player.rage >= 85 )'}, -- shield_barrier,if=buff.shield_barrier.down&((buff.shield_block.down&action.shield_block.charges_fractional<0.75)|rage>=85)


### PR DESCRIPTION
Solves the lua error at loggin, but warrior rotation don't work and returns an error with onclick

Message: Interface\AddOns\KPS\modules\spell\spell_state.lua:58: bad argument #1 to 'rawget' (table expected, got nil)
Time: Sat Jul  4 12:16:07 2015
Count: 5
Stack: [C]: in function `rawget'
Interface\AddOns\KPS\modules\spell\spell_state.lua:58: in function <Interface\AddOns\KPS\modules\spell\spell_state.lua:57>
(tail call): ?
Interface\AddOns\KPS\core\kps.lua:87: in function <Interface\AddOns\KPS\core\kps.lua:82>
[C]: in function `UseAction'
Interface\FrameXML\SecureTemplates.lua:348: in function `handler'
Interface\FrameXML\SecureTemplates.lua:649: in function `SecureActionButton_OnClick'
[string "*:OnClick"]:2: in function <[string "*:OnClick"]:1>

Locals: (*temporary) = nil
(*temporary) = "_isPrioritySpell"
(*temporary) = "table expected, got nil"
