### PR TITLE
Update keys.lua

### DIFF
--- a/modules/keys.lua
+++ b/modules/keys.lua
@@ -10,7 +10,7 @@ kps.Keys.metatable = {}
 @function `keys.shift` - SHIFT Key
 ]]--
 function kps.Keys.prototype.shift(self)
-    return IsShiftKeyDown()
+    return IsShiftKeyDown() and not GetCurrentKeyBoardFocus()
 end
 --[[[
 @function `keys.alt` - ALT Key


### PR DESCRIPTION
- added "and not GetCurrentKeyBoardFocus()" to prevent keys.shift from triggering when using the shift button while typing in the chatbox